### PR TITLE
Remove improper generics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,8 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
+[*.{neon,neon.dist}]
+indent_style = tab
+
 [*.{yml,yaml}]
 indent_size = 2

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,7 +13,7 @@ parameters:
 
 	# Paths to be analyzed.
 	paths:
-		- %currentWorkingDirectory%/src/
+		- src
 
 	# Additional checks.
 	polluteScopeWithLoopInitialAssignments: true

--- a/src/Container.php
+++ b/src/Container.php
@@ -27,7 +27,7 @@ abstract class Container implements ContainerInterface
     /**
      * A cache of all resolved dependencies.
      *
-     * @var Array<string|class-string<T>,mixed|T> The resolved dependency, keyed by its abstract.
+     * @var Array<string,object> The resolved dependency, keyed by its abstract.
      */
     protected $resolved = [];
 
@@ -59,11 +59,11 @@ abstract class Container implements ContainerInterface
      *                             Like those in config(), each callable will recieve the current
      *                             container instance.
      *
-     * @return self
+     * @return $this
      */
     public function extend($abstract, callable $definition)
     {
-        $this->extensions[ $abstract ] = $definition;
+        $this->extensions[$abstract] = $definition;
 
         return $this->forget($abstract);
     }
@@ -73,11 +73,11 @@ abstract class Container implements ContainerInterface
      *
      * @param string $abstract The abstract identifier to forget.
      *
-     * @return self
+     * @return $this
      */
     public function forget($abstract)
     {
-        unset($this->resolved[ $abstract ]);
+        unset($this->resolved[$abstract]);
 
         return $this;
     }
@@ -87,20 +87,21 @@ abstract class Container implements ContainerInterface
      *
      * Results will be cached, enabling subsequent results to return the same instance.
      *
-     * @param string|class-string<T> $abstract The dependency's abstract identifier.
+     * @param string $abstract The dependency's abstract identifier.
      *
      * @throws NotFoundException  If no entry was found for this abstract.
      * @throws ContainerException Error while retrieving the entry.
      *
-     * @return mixed|T The resolved dependency.
+     * @return object The resolved dependency.
      */
     public function get($abstract)
     {
         if (! array_key_exists($abstract, $this->resolved)) {
-            $this->resolved[ $abstract ] = $this->make($abstract);
+            $resolved = $this->make($abstract);
+            $this->resolved[$abstract] = $resolved;
         }
 
-        return $this->resolved[ $abstract ];
+        return $this->resolved[$abstract];
     }
 
     /**
@@ -138,12 +139,12 @@ abstract class Container implements ContainerInterface
      *
      * Unlike get(), a new, uncached instance will be created upon each call.
      *
-     * @param string|class-string<T> $abstract The dependency's abstract identifier.
+     * @param string $abstract The dependency's abstract identifier.
      *
      * @throws NotFoundException  If no entry was found for this abstract.
      * @throws ContainerException Error while retrieving the entry.
      *
-     * @return mixed|T The resolved dependency.
+     * @return object The resolved dependency.
      */
     public function make($abstract)
     {
@@ -156,11 +157,11 @@ abstract class Container implements ContainerInterface
         }
 
         try {
-            if (null === $config[ $abstract ]) {
+            if (null === $config[$abstract]) {
                 return new $abstract();
             }
 
-            $resolved = $config[ $abstract ]($this);
+            $resolved = $config[$abstract]($this);
         } catch (\Exception $e) {
             throw new ContainerException(
                 sprintf('An error occured building "%s": %s', $abstract, $e->getMessage()),
@@ -177,11 +178,11 @@ abstract class Container implements ContainerInterface
      *
      * @param string $abstract The abstract to restore.
      *
-     * @return self
+     * @return $this
      */
     public function restore($abstract)
     {
-        unset($this->extensions[ $abstract ]);
+        unset($this->extensions[$abstract]);
 
         return $this->forget($abstract);
     }
@@ -232,11 +233,11 @@ abstract class Container implements ContainerInterface
      *
      * @throws ContainerException If the container cannot be constructed.
      *
-     * @return Container
+     * @return static
      */
     protected static function buildSingleton()
     {
-        $constructor = ( new \ReflectionClass(static::class) )->getConstructor();
+        $constructor = (new \ReflectionClass(static::class))->getConstructor();
         $required    = $constructor ? $constructor->getNumberOfRequiredParameters() : 0;
 
         if (0 < $required) {

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -160,6 +160,7 @@ class ContainerTest extends TestCase
     public function get_should_retrieve_the_given_abstract()
     {
         $container = new Concrete();
+        /** @var callable $callable */
         $callable  = $container->config()[ Concrete::VALID_KEY ];
 
         $this->assertEquals(
@@ -463,6 +464,6 @@ class ContainerTest extends TestCase
         $property = new \ReflectionProperty($container, 'resolved');
         $property->setAccessible(true);
 
-        return $property->getValue($container);
+        return (array) $property->getValue($container);
     }
 }


### PR DESCRIPTION
While generics would be great in the container, the previous implementation was flawed and may be incompatible with PSR-11 as it stands today.

It's also extremely possible that I'm just misunderstanding their purpose :/

Until we can get them properly implemented, remove them and plan on `/** @type ... */` declarations in places where we're accessing Container resolutions directly.