### PR TITLE
Enable Container::extend() to receive a concrete instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,16 @@ public function saveUser_should_update_the_account_email()
 }
 ```
 
+You may also pass the resolved instance directly into the container with `extend()`:
+
+```diff
+   // Replace the default ServiceSdk instance with our mock.
+-  $this->container->extend(ServiceSdk::class, function () use ($service) {
+-    return $service;
+-  });
++  $this->container->extend(ServiceSdk::class, $service);
+```
+
 > #### ⏮  Restoring original definitions
 > If you need to restore the original definition for an abstract, you may remove its extension(s) using `$container->restore()`.
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -37,7 +37,7 @@ abstract class Container implements ContainerInterface
     /**
      * Extensions to the default container configuration.
      *
-     * @var Array<string,callable> A mapping of abstracts to callables.
+     * @var Array<string,callable|object|string|null> A mapping of abstracts to callables.
      */
     protected $extensions = [];
 
@@ -61,7 +61,7 @@ abstract class Container implements ContainerInterface
      * When an abstract is requested through the container, the container will find the given
      * dependency in this array, execute the callable, and return the result.
      *
-     * @return Array<string,callable|null> A mapping of abstracts to callables.
+     * @return Array<string,callable|object|string|null> A mapping of abstracts to callables.
      */
     abstract public function config();
 
@@ -71,18 +71,26 @@ abstract class Container implements ContainerInterface
      * This allows definitions to be dynamically added or updated, which is especially useful
      * during testing.
      *
-     * @param string   $abstract   The abstract to be added or replaced.
-     * @param callable $definition A callable to construct the concrete instance of the abstract.
-     *                             Like those in config(), each callable will recieve the current
-     *                             container instance.
+     * @param string          $abstract   The abstract to be added or replaced.
+     * @param callable|object $definition Either the resolved dependency object or a callable that
+     *                                    can be used to construct the concrete instance of the
+     *                                    abstract. Like those in config(), each callable will recieve
+     *                                    the current container instance.
      *
      * @return $this
      */
-    public function extend($abstract, callable $definition)
+    public function extend($abstract, $definition)
     {
         $this->extensions[$abstract] = $definition;
 
-        return $this->forget($abstract);
+        // If we have a resolved, concrete instance go ahead and prime the cache.
+        if (is_object($definition) && ! $definition instanceof \Closure) {
+            $this->resolved[$abstract] = $definition;
+        } else {
+            $this->forget($abstract);
+        }
+
+        return $this;
     }
 
     /**
@@ -192,9 +200,17 @@ abstract class Container implements ContainerInterface
             } elseif (is_string($config[$abstract]) && $this->has($config[$abstract])) {
                 $resolved = $this->make($config[$abstract]);
 
-            // Otherwise, attempt to execute the callable.
-            } else {
+            // If the definition is a non-closure object, simply return it.
+            } elseif (is_object($config[$abstract]) && ! $config[$abstract] instanceof \Closure) {
+                $resolved = $config[$abstract];
+
+            // If the definition is callable, execute it and return the result.
+            } elseif (is_callable($config[$abstract])) {
                 $resolved = $config[$abstract]($this);
+
+            // If all else fails, throw an exception.
+            } else {
+                throw new ContainerException(sprintf('Unhandled definition type (%s)', gettype($config[$abstract])));
             }
         } catch (\Exception $e) {
             if ($e instanceof RecursiveDependencyException) {

--- a/tests/Stubs/Concrete.php
+++ b/tests/Stubs/Concrete.php
@@ -11,11 +11,13 @@ class Concrete extends Container
      */
     const ALIAS_KEY       = 'alias';
     const EXCEPTION_KEY   = 'exception';
+    const INSTANCE_KEY    = 'instance';
     const INVALID_KEY     = 'some-other-key';
     const NESTED_GET_KEY  = 'nested-get-key';
     const NESTED_MAKE_KEY = 'nested-make-key';
     const NULL_KEY        = \DateTime::class;
     const RECURSIVE_KEY   = 'recursion';
+    const UNDEFINED_KEY   = 'undefined';
     const VALID_KEY       = 'some-key';
 
     /**
@@ -41,7 +43,9 @@ class Concrete extends Container
             self::EXCEPTION_KEY => function () {
                 throw new \RuntimeException('Something went wrong');
             },
-            // self::INVALID_KEY should not be in this array.
+            self::INSTANCE_KEY  => new \stdClass(),
+            self::INVALID_KEY   => [],
+            // self::UNDEFINED_KEY should not be in this array.
         ];
     }
 }

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -59,11 +59,39 @@ class ContainerTest extends TestCase
         $instance  = new \stdClass();
         $container = new Concrete();
 
-        $container->extend(Concrete::INVALID_KEY, function () use ($instance) {
+        $container->extend(Concrete::UNDEFINED_KEY, function () use ($instance) {
             return $instance;
         });
 
-        $this->assertSame($instance, $container->get(Concrete::INVALID_KEY));
+        $this->assertSame($instance, $container->make(Concrete::UNDEFINED_KEY));
+    }
+
+    /**
+     * @test
+     * @testdox extend() should be able to accept new instances directly
+     */
+    public function extend_should_be_able_to_accept_new_instances_directly()
+    {
+        $instance  = new \stdClass();
+        $container = new Concrete();
+
+        $container->extend(Concrete::UNDEFINED_KEY, $instance);
+
+        $this->assertSame($instance, $container->make(Concrete::UNDEFINED_KEY));
+    }
+
+    /**
+     * @test
+     * @testdox extend() should prime the resolution cache if given a concrete instance
+     */
+    public function extend_Should_prime_the_resolution_cache_if_given_a_concrete_instance()
+    {
+        $instance  = new \stdClass();
+        $container = new Concrete();
+
+        $container->extend(Concrete::UNDEFINED_KEY, $instance);
+
+        $this->assertTrue($container->hasResolved(Concrete::UNDEFINED_KEY));
     }
 
     /**
@@ -96,14 +124,10 @@ class ContainerTest extends TestCase
         $instance1 = (object) [ uniqid() ];
         $instance2 = (object) [ uniqid() ];
 
-        $container->extend(Concrete::VALID_KEY, function () use ($instance1) {
-            return $instance1;
-        });
+        $container->extend(Concrete::VALID_KEY, $instance1);
         $this->assertSame($instance1, $container->get(Concrete::VALID_KEY));
 
-        $container->extend(Concrete::VALID_KEY, function () use ($instance2) {
-            return $instance2;
-        });
+        $container->extend(Concrete::VALID_KEY, $instance2);
         $this->assertSame($instance2, $container->get(Concrete::VALID_KEY));
     }
 
@@ -211,9 +235,7 @@ class ContainerTest extends TestCase
         $container = new Concrete();
         $instance = (object) [ uniqid() ];
 
-        $container->extend(Concrete::VALID_KEY, function () use ($instance) {
-            return $instance;
-        });
+        $container->extend(Concrete::VALID_KEY, $instance);
 
         $this->assertSame($instance, $container->get(Concrete::ALIAS_KEY));
         $this->assertTrue(
@@ -233,7 +255,7 @@ class ContainerTest extends TestCase
     public function get_should_throw_a_NotFoundException_if_the_given_entry_is_undefined()
     {
         $this->expectException(NotFoundException::class);
-        (new Concrete())->get(Concrete::INVALID_KEY);
+        (new Concrete())->get(Concrete::UNDEFINED_KEY);
     }
 
     /**
@@ -276,7 +298,7 @@ class ContainerTest extends TestCase
      */
     public function has_should_return_false_if_no_definition_for_the_abstract_exists()
     {
-        $this->assertFalse((new Concrete())->has(Concrete::INVALID_KEY));
+        $this->assertFalse((new Concrete())->has(Concrete::UNDEFINED_KEY));
     }
 
     /**
@@ -304,6 +326,20 @@ class ContainerTest extends TestCase
 
         $this->assertInstanceOf(Concrete::NULL_KEY, $container->make(Concrete::NULL_KEY));
         $this->assertFalse($container->hasResolved(Concrete::NULL_KEY));
+    }
+
+    /**
+     * @test
+     * @testdox make() should return the provided resolved instance, when present
+     */
+    public function make_should_return_the_provided_resolved_instance_when_present()
+    {
+        $container = new Concrete();
+        $instance  = new \stdClass();
+
+        $container->extend(Concrete::INSTANCE_KEY, $instance);
+
+        $this->assertSame($instance, $container->make(Concrete::INSTANCE_KEY));
     }
 
     /**
@@ -367,7 +403,7 @@ class ContainerTest extends TestCase
     public function make_should_throw_a_NotFoundException_if_the_given_abstract_is_undefined()
     {
         $this->expectException(NotFoundException::class);
-        ( new Concrete() )->make(Concrete::INVALID_KEY);
+        ( new Concrete() )->make(Concrete::UNDEFINED_KEY);
     }
 
     /**
@@ -380,6 +416,18 @@ class ContainerTest extends TestCase
 
         $this->expectException(ContainerException::class);
         $container->make(Concrete::EXCEPTION_KEY);
+    }
+
+    /**
+     * @test
+     * @testdox make() should throw a ContainerException if unable to process a definition
+     */
+    public function make_should_throw_a_ContainerException_if_unable_to_process_a_definition()
+    {
+        $container = new Concrete();
+
+        $this->expectException(ContainerException::class);
+        $container->make(Concrete::INVALID_KEY);
     }
 
     /**
@@ -428,8 +476,8 @@ class ContainerTest extends TestCase
     {
         $container = new Concrete();
 
-        $this->assertArrayNotHasKey(Concrete::INVALID_KEY, $this->getResolvedCache($container));
-        $this->assertFalse($container->hasResolved(Concrete::INVALID_KEY));
+        $this->assertArrayNotHasKey(Concrete::UNDEFINED_KEY, $this->getResolvedCache($container));
+        $this->assertFalse($container->hasResolved(Concrete::UNDEFINED_KEY));
     }
 
     /**


### PR DESCRIPTION
Often during testing, we find ourselves writing things like this:

```php
$container->extend(SomeAbstract::class, function () use ($instance) {
    return $instance;
});
```

Thanks to this PR, we can now write this in a much shorter form:

```php
$container->extend(SomeAbstract::class, $instance);
```

Furthermore, we can use this to prime the resolution cache, saving an extra method call.

This PR also adds additional error handling to `make()` so that, in the event that we're unable to handle a definition, a more-helpful `ContainerException` is thrown:

> **StellarWP\Container\Exceptions\ContainerException:** An error occured building "SomeAbstract": Unhandled definition type (array)