### PR TITLE
Add a "provide" declaration to the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
         "szepeviktor/phpstan-wordpress": "^1.0",
         "yoast/phpunit-polyfills": "^1.0"
     },
+    "provide": {
+        "psr/container-implementation": "^1.0.0"
+    },
     "scripts": {
         "test": [
             "@test:all"


### PR DESCRIPTION
[According to the PSR-11 specification](https://www.php-fig.org/psr/psr-11/#2-package), packages that provide a PSR-11 implementation should declare so in `composer.json`:

> Packages providing a PSR container implementation should declare that they provide `psr/container-implementation` `1.0.0`.