### PR TITLE
Prevent make() from overwriting cached resolutions of nested dependencies

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -230,7 +230,7 @@ abstract class Container implements ContainerInterface
         }
 
         // If the cache is enabled, cache this resolution.
-        if ($this->resolutionCacheDepth > 0) {
+        if ($this->resolutionCacheDepth > 0 && ! array_key_exists($abstract, $this->resolved)) {
             $this->resolved[$abstract] = $resolved;
         }
 

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -440,6 +440,19 @@ class ContainerTest extends TestCase
 
     /**
      * @test
+     * @testdox Calling make() should not overwrite cached resolutions
+     */
+    public function calling_make_should_not_overwrite_nested_cached_resolutions()
+    {
+        $container = new Concrete();
+        $valid     = $container->get(Concrete::VALID_KEY);
+
+        $container->get(Concrete::NESTED_MAKE_KEY);
+        $this->assertSame($valid, $container->get(Concrete::VALID_KEY));
+    }
+
+    /**
+     * @test
      * @testdox make() should throw a NotFoundException if the given abstract is undefined
      */
     public function make_should_throw_a_NotFoundException_if_the_given_abstract_is_undefined()


### PR DESCRIPTION
It's generally recommended that implementations of the container use `$app->make()` within resolutions, since the container is smart enough to cache the dependency chain if called via `get()` (or not if called via `make()`), but there was some confusion when both were used.

For example, imagine the following configuration:

```php
return [
    FirstClass::class => function ($app) {
        return new FirstClass(
            $app->make(SecondClass::class)
        );
    },
    SecondClass::class => function ($app) {
        return new SecondClass();
    },
];
```

When calling `$container->get(FirstClass::class)`, we should see the resolution cache populated for both `FirstClass` and `SecondClass`.

However, imagine that we had first injected a concrete instance of `SecondClass` into the container:

```php
$second = new SecondClass();
$container->extend(SecondClass::class, $second);
var_dump($second === $container->get(SecondClass::class));
# => bool(true)

$container->get(FirstClass::class);
var_dump($second === $container->get(SecondClass::class));
# => bool(false)
```

This was happening due to `Container::make()` caching the resolution if whenever `Container::$resolutionCacheDepth` was greater than zero, without checking to see if a resolution already existed.