### PR TITLE
Remove references to "secrets.STELLARWP_ACCESS_TOKEN" in the CI pipeline

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,9 +32,6 @@ jobs:
           extensions: mbstring, intl
           coverage: none
 
-      - name: Configure Composer
-        run: composer config github-oauth.github.com ${{ secrets.STELLARWP_ACCESS_TOKEN }}
-
       - name: Remove unneeded Composer dependencies
         run: |
           composer remove --dev --no-progress --no-update \
@@ -61,9 +58,6 @@ jobs:
           extensions: mbstring
           coverage: none
 
-      - name: Configure Composer
-        run: composer config github-oauth.github.com ${{ secrets.STELLARWP_ACCESS_TOKEN }}
-
       - uses: ramsey/composer-install@v2
 
       - name: Check coding standards
@@ -82,9 +76,6 @@ jobs:
           php-version: '8.0'
           extensions: mbstring, intl
           coverage: none
-
-      - name: Configure Composer
-        run: composer config github-oauth.github.com ${{ secrets.STELLARWP_ACCESS_TOKEN }}
 
       - uses: ramsey/composer-install@v2
 


### PR DESCRIPTION
Before this repo and stellarwp/coding-standards were made public, we needed to authenticate within GitHub Actions using an auth token.

However, this is no longer the case now that the repos are public.